### PR TITLE
Drag ghost image styling

### DIFF
--- a/client/src/hooks/useDragDrop.js
+++ b/client/src/hooks/useDragDrop.js
@@ -96,7 +96,7 @@ export function useDragDrop(stateRef, dispatch, stageRef, splitViewActions) {
       if (!isDragThresholdMet(distance, timeDelta, DRAG_THRESHOLD_DISTANCE, DRAG_THRESHOLD_TIME)) return;
 
       const el = document.querySelector(`[data-work-item-id="${ds.item.id}"]`);
-      ghostRef.current = createGhostElement(el, e.clientX, e.clientY);
+      ghostRef.current = createGhostElement(el, e.clientX, e.clientY, { preserveStyle: true });
       if (ghostRef.current) document.body.appendChild(ghostRef.current);
 
       dispatch({ type: 'SET_DRAG_STATE', payload: { isDragging: true, dragSource: 'sidebar' } });
@@ -124,7 +124,13 @@ export function useDragDrop(stateRef, dispatch, stageRef, splitViewActions) {
     const onEnd = () => {
       const { dropZone } = stateRef.current.dragThreshold;
       const item = dragStateRef.current?.item;
-      removeGhostElement(ghostRef.current);
+      const ghost = ghostRef.current;
+      if (ghost) {
+        ghost.style.transform = 'translate(-50%, -50%) rotate(0deg)';
+        ghost.style.opacity = '0';
+        ghost.addEventListener('transitionend', () => removeGhostElement(ghost), { once: true });
+        setTimeout(() => removeGhostElement(ghost), 200);
+      }
       ghostRef.current = null;
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onEnd);

--- a/client/src/utils/dragHelpers.js
+++ b/client/src/utils/dragHelpers.js
@@ -41,7 +41,7 @@ export const createGhostElement = (sourceElement, clientX, clientY, { preserveSt
     const rect = sourceElement.getBoundingClientRect();
     ghost.style.width = `${rect.width}px`;
     ghost.style.opacity = '0.85';
-    ghost.style.transform = 'translate(-50%, -50%) rotate(-4deg)';
+    ghost.style.transform = 'translate(-50%, -50%) rotate(4deg)';
     ghost.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.2)';
     ghost.style.transition = 'transform 0.15s ease-out';
   } else {

--- a/client/src/utils/dragHelpers.js
+++ b/client/src/utils/dragHelpers.js
@@ -26,17 +26,28 @@ export const detectSplitPaneDropZone = (clientX, stageRect, splitterPosition) =>
   return clientX < splitterX ? 'left' : 'right';
 };
 
-export const createGhostElement = (tabElement, clientX, clientY) => {
-  if (!tabElement) return null;
-  const ghost = tabElement.cloneNode(true);
-  ghost.className = 'stage-drag-ghost';
+export const createGhostElement = (sourceElement, clientX, clientY, { preserveStyle = false } = {}) => {
+  if (!sourceElement) return null;
+  const ghost = sourceElement.cloneNode(true);
+  if (!preserveStyle) {
+    ghost.className = 'stage-drag-ghost';
+  }
   ghost.style.position = 'fixed';
   ghost.style.pointerEvents = 'none';
   ghost.style.zIndex = '1000';
-  ghost.style.opacity = '0.8';
   ghost.style.left = `${clientX}px`;
   ghost.style.top = `${clientY}px`;
-  ghost.style.transform = 'translate(-50%, -50%)';
+  if (preserveStyle) {
+    const rect = sourceElement.getBoundingClientRect();
+    ghost.style.width = `${rect.width}px`;
+    ghost.style.opacity = '0.85';
+    ghost.style.transform = 'translate(-50%, -50%) rotate(-4deg)';
+    ghost.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.2)';
+    ghost.style.transition = 'transform 0.15s ease-out';
+  } else {
+    ghost.style.opacity = '0.8';
+    ghost.style.transform = 'translate(-50%, -50%)';
+  }
   return ghost;
 };
 


### PR DESCRIPTION
## Summary

- Style the sidebar drag ghost to match the work item card appearance — preserves original classes, layout, title/description/date
- Subtle right-leaning tilt (~4deg) following the natural left-to-right drag direction
- Drop shadow and slight transparency (0.85) for depth
- On drop, ghost animates back to horizontal and fades out via CSS transition

## Test plan

- [x] `npm test` — 53 unit tests pass
- [x] `npm run test:e2e` — sidebar drag tests pass (6/6)
- [ ] Visual: drag work item from sidebar, verify ghost matches card styling with tilt
- [ ] Visual: release drag, verify ghost snaps horizontal and fades

🤖 Generated with [Claude Code](https://claude.com/claude-code)